### PR TITLE
Example for configuring resetPwd with ensureSignedIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,23 @@ AccountsTemplates.configureRoute('ensureSignedIn', {
     layoutTemplate: 'myLayout',
 });
 ```
+
+When using the **ensureSignedIn** plugin with the **except** parameter make sure the password reset token is configured properly on your route and you have a publication:
+
+```javascript
+AccountsTemplates.configureRoute('resetPwd', {
+  waitOn: function(){
+    return Meteor.subscribe('enrolledUser',this.params.paramToken);
+  },
+  data: function(){
+    if(Meteor.userId())  Router.go('root'); // redirect the logged in user to a route
+    else return Meteor.users.findOne();
+  }
+});
+
+// publication (somewhere in /server)
+Meteor.publish('enrolledUser', function(token) {
+  check(token, Match.Any);
+  return Meteor.users.find({"services.password.reset.token": token}, {fields: {_id: 1}});
+});
+```


### PR DESCRIPTION
Docs were lacking an example of what is required when you are using ensureSignedIn with the except parameter and you want to enable reset password (or any other route that requires a token)

I ran into this issue on our app and wanted to share how someone can solve it without having to dig through useraccounts core to find the token parameter that they need to set.
