### PR TITLE
fix path of undefined error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -132,7 +132,8 @@ AccountsTemplates.linkClick = function(route){
     return;
   }
   var path = AccountsTemplates.getRoutePath(route);
-  if (path === '#' || AccountsTemplates.avoidRedirect || path === Router.current().route.path()) {
+  if (path === '#' || AccountsTemplates.avoidRedirect ||
+     (Router.current().route && path === Router.current().route.path())) {
     AccountsTemplates.setState(route);
   }
   else {


### PR DESCRIPTION
If `Router.current()` is "notFound", or some other route that is not handled by iron router, the original implementation will throw an error because: 

``` javascript

Router.current().route is undefined

```

We can also use `Router.current()._handled` to determine whether it is defined, but I think it is supposed to be an interval variable, hence `Router.current().route`.
