### PR TITLE
use defalult route name 'atForgotPwd'

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ While in case you want to protect *almost all* your routes you might want to set
 
 ```javascript
 Router.plugin('ensureSignedIn', {
-    except: ['home', 'atSignIn', 'atSignUp', 'atForgotPassword']
+    except: ['home', 'atSignIn', 'atSignUp', 'atForgotPwd']
 });
 ```
 


### PR DESCRIPTION
Better this way, when defalut route name for forgot password is 'atForgotPwd' not 'atForgotPassword'
